### PR TITLE
Precompile image assets

### DIFF
--- a/lib/jquery-colorbox-rails/engine.rb
+++ b/lib/jquery-colorbox-rails/engine.rb
@@ -1,4 +1,8 @@
 module JqueryColorboxRails
 	class Engine < ::Rails::Engine
+			config.assets.precompile += %w(
+				colorbox/*.png
+				colorbox/*.gif
+			)
 	end
 end


### PR DESCRIPTION
Rails will only precompile JS and CSS by default. If we want these images to be present in precompiled assets, we have to specify them ourselves.
